### PR TITLE
fix broken htrfin after commit 6c05a5accff2055ddac64504571e52d945bcd372

### DIFF
--- a/src/alg.c
+++ b/src/alg.c
@@ -58,7 +58,7 @@ moveset_htr = {
 	.allowed_next = allowed_next_HTM,
 };
 
-static int nmoveset = 5;
+static int nmoveset = 6;
 static Moveset * all_ms[] = {
 	&moveset_HTM,
 	&moveset_URF,


### PR DESCRIPTION
there is 6 moveset after these commit, which cause htrfin never work after that commit.